### PR TITLE
bumped version of gevent so that this works on python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 COPY . /src/smartglass-core
 
 # install the C compiler
-RUN apk add --no-cache jq gcc musl-dev libffi-dev openssl-dev
+RUN apk add --no-cache jq gcc musl-dev libffi-dev openssl-dev file
 
 # instead of installing, create a wheel
 RUN pip wheel --wheel-dir=/root/wheels /src/smartglass-core

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     'xbox-webapi>=1.1.8',
     'construct==2.10.56',
     'cryptography==2.8',
-    'gevent==1.5a3',
+    'gevent==20.9.0',
     'dpkt',
     'marshmallow-objects',
     'Flask'


### PR DESCRIPTION
bumped version of gevent so on python 3.8 commands like 'xbox-cli discover' don't fail